### PR TITLE
Update registry name

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,14 +59,14 @@ jobs:
         with:
           ecr: true
           logout: true
-          registry: 505875808047.dkr.ecr.ap-south-1.amazonaws.com
+          registry: 505875808047.dkr.ecr.ap-south-1.amazonaws.com/mailer-service
       - name: Checkout
         uses: actions/checkout@v6
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: 505875808047.dkr.ecr.ap-south-1.amazonaws.com/wecoach-mailer-service
+          images: 505875808047.dkr.ecr.ap-south-1.amazonaws.com/mailer-service
           tags: type=sha
       - name: Build
         run: docker image build --file build/Dockerfile --tag ${{ steps.meta.outputs.tags }} .


### PR DESCRIPTION
This pull request updates the deployment workflow configuration to use a new ECR image path for the mailer service. The main changes involve updating the ECR registry and image references to point to `mailer-service` instead of `wecoach-mailer-service`.

**Deployment workflow updates:**

* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L62-R69): Changed the ECR registry and Docker image references from `wecoach-mailer-service` to `mailer-service` to align with the new image naming convention.